### PR TITLE
replace rn-fetch-blob with react-native-blob-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import {
     Platform,
     NativeModules,
 } from 'react-native';
-import RNFetchBlob from 'rn-fetch-blob';
+import ReactNativeBlobUtil from 'react-native-blob-util';
 
 const RNUpgrade = NativeModules.upgrade;
 const ANDROID_PLATFORM = Platform.OS === 'android';
@@ -103,7 +103,7 @@ export const downloadApk = async ({
     //     RNUpgrade.installApk(downloadApkFilePath);
     //     return;
     // }
-    const downloadTask = await RNFetchBlob
+    const downloadTask = await ReactNativeBlobUtil
         .config({ path: apkFilePath })
         .fetch('GET', apkUrl)
         .progress({ interval }, (received, total) => {
@@ -138,7 +138,7 @@ export const checkPlayStoreInstalled = async () => {
  */
 export const checkApkFileExist = async (fileName) => {
     const path = RNUpgrade.downloadApkFilePath + fileName;
-    return await RNFetchBlob.fs.exists(path);
+    return await ReactNativeBlobUtil.fs.exists(path);
 }
 
 export const installApk = async (fileName) => {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/songxiaoliang/react-native-app-upgrade#readme",
   "dependencies": {
-    "rn-fetch-blob": "^0.12.0"
+    "react-native-blob-util": "^0.13.17"
   }
 }


### PR DESCRIPTION
`rn-fetch-blob` 已不再维护，此更新主要是为了消除 Require cycle 的 warning，根据 https://github.com/joltup/rn-fetch-blob/issues/666 可替换为 `react-native-blob-util`。